### PR TITLE
Feature: Optimize Docker image size with multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,76 @@
 # syntax=docker/dockerfile:1
 
-# Build arguments with specific versions for better reproducibility
+# Build stage
 ARG RUBY_VERSION=3.1
 ARG DISTRO_NAME=slim-bookworm
-
-FROM ruby:${RUBY_VERSION}-${DISTRO_NAME}
+FROM ruby:${RUBY_VERSION}-${DISTRO_NAME} AS builder
 
 WORKDIR /srv/ontoportal/ncbo_cron
 
-# Set environment variables
+# Set environment variables for build phase
 ENV BUNDLE_PATH=/srv/ontoportal/bundle \
     BUNDLE_JOBS=4 \
     BUNDLE_RETRY=5 \
     DEBIAN_FRONTEND=noninteractive
 
-# Install system dependencies
+# Install build dependencies only
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        file \
+        build-essential \
+        libxml2-dev \
+        libxslt-dev \
+        libmariadb-dev \
+        libffi-dev \
+        libraptor2-dev \
+        pkg-config \
+        git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install bundler and dependencies
+RUN gem install bundler
+
+# Copy only the Gemfile-related files first to leverage Docker cache
+COPY Gemfile* *.gemspec ./
+
+# Install gems
+RUN bundle install --jobs ${BUNDLE_JOBS} --retry ${BUNDLE_RETRY} \
+    && bundle clean --force \
+    && find ${BUNDLE_PATH} -name "*.c" -delete \
+    && find ${BUNDLE_PATH} -name "*.o" -delete \
+    && find ${BUNDLE_PATH} -name ".git" -type d -exec rm -rf {} + 2>/dev/null || true
+
+# Final stage
+FROM ruby:${RUBY_VERSION}-${DISTRO_NAME} AS app
+
+WORKDIR /srv/ontoportal/ncbo_cron
+
+# Set environment variables for runtime
+ENV BUNDLE_PATH=/srv/ontoportal/bundle \
+    DEBIAN_FRONTEND=noninteractive
+
+# Install only runtime dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
         ca-certificates \
         openjdk-17-jre-headless \
         raptor2-utils \
         wait-for-it \
-        libraptor2-dev \
-        build-essential \
-         libxml2 \
-         libxslt-dev \
-         libmariadb-dev \
-         git \
-         curl \
-         libffi-dev \
-     pkg-config && \
+        libxml2 \
+        libxslt1.1 \
+        libmariadb3 \
+        libraptor2-0 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN gem install bundler
-
-COPY Gemfile* *.gemspec ./
-
-# Install dependencies
-RUN bundle install --jobs ${BUNDLE_JOBS} --retry ${BUNDLE_RETRY}
+# Copy bundled gems from builder stage
+COPY --from=builder ${BUNDLE_PATH} ${BUNDLE_PATH}
 
 # Copy application code
 COPY . .
+
+# Configure the application
 RUN cp /srv/ontoportal/ncbo_cron/config/config.rb.sample /srv/ontoportal/ncbo_cron/config/config.rb
 
+# Set the default command
 CMD ["/bin/bash"]


### PR DESCRIPTION
Optimize Docker image size with multi-stage build. Related issue https://github.com/ontoportal-lirmm/ncbo_cron/issues/33
- Implement two-stage Docker build process to separate build and runtime environments
- Reduce final image size by excluding build tools and development dependencies

**Before**
```
REPOSITORY                     TAG             IMAGE ID       CREATED             SIZE
agroportal/ncbo_cron           master          9a38d350022f   2 weeks ago         4.17GB
```
**After**
```
REPOSITORY                     TAG             IMAGE ID       CREATED             SIZE
my_ncbo_light                  latest          661a5f5fee5f   About an hour ago   2.36GB
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved Docker image build process with a multi-stage approach, resulting in a smaller and more efficient final image. No changes to application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->