### PR TITLE
ci: manual workflow to refresh Gemfile.lock git revisions

### DIFF
--- a/.github/workflows/update-gemfile-lock.yml
+++ b/.github/workflows/update-gemfile-lock.yml
@@ -1,0 +1,82 @@
+# Manually-triggered refresh of the git-sourced gems in Gemfile.lock.
+#
+# Run it from Actions -> Update Gemfile.lock -> Run workflow. The branch picker selects
+# the base branch (master by default); the result is proposed as a pull request against
+# it, since the protected branches don't accept direct pushes.
+name: Update Gemfile.lock
+
+on:
+  workflow_dispatch:
+    inputs:
+      gems:
+        description: 'Space-separated gems to refresh'
+        default: 'ontologies_linked_data goo sparql-client ncbo_annotator'
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-lock:
+    runs-on: ubuntu-latest
+    env:
+      # One branch per base branch, so re-running the workflow updates the open PR
+      # instead of piling up new ones.
+      BRANCH: bot/update-gemfile-lock-${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1.0'
+          bundler-cache: false   # we only re-resolve, we never install the gems
+
+      - name: Refresh git revisions in Gemfile.lock
+        id: relock
+        env:
+          GEMS: ${{ inputs.gems }}
+        run: |
+          set -eu
+          UPDATE_FLAGS=""
+          for gem in $GEMS; do
+            UPDATE_FLAGS="$UPDATE_FLAGS --update=$gem"
+          done
+          # --conservative: bump the git revision only, don't drag shared rubygems deps along
+          bundle lock $UPDATE_FLAGS --conservative
+
+          if git diff --quiet -- Gemfile.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Gemfile.lock is already up to date."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git --no-pager diff -- Gemfile.lock
+          fi
+
+      - name: Push branch and open pull request
+        if: steps.relock.outputs.changed == 'true'
+        env:
+          GEMS: ${{ inputs.gems }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git checkout -b "$BRANCH"
+          git add Gemfile.lock
+          git commit -m 'build: update Gemfile.lock to latest dependency revisions'
+          git push --force origin "HEAD:refs/heads/$BRANCH"
+
+          if [ -n "$(gh pr list --head "$BRANCH" --base "$GITHUB_REF_NAME" --state open --json number --jq '.[].number')" ]; then
+            echo "Updated the existing pull request for $BRANCH."
+          else
+            BODY=$(printf '%s\n\n%s\n' \
+              "Refreshed git revisions in \`Gemfile.lock\` for: \`$GEMS\`." \
+              "Opened by the [Update Gemfile.lock]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) workflow.")
+            gh pr create \
+              --base "$GITHUB_REF_NAME" \
+              --head "$BRANCH" \
+              --title 'build: update Gemfile.lock to latest dependency revisions' \
+              --body "$BODY"
+          fi


### PR DESCRIPTION
Same workflow as ontologies_api#190. `workflow_dispatch` re-resolves the git-sourced gems (`bundle lock --update=<gem> --conservative`), commits to `bot/update-gemfile-lock-<base>` and opens a PR against the branch picked at dispatch. Re-runs update that PR rather than opening new ones.

Defaults to all four git gems: `ontologies_linked_data goo sparql-client ncbo_annotator`.

Caveat: PRs opened with `GITHUB_TOKEN` do not trigger other workflows, so unit tests will not run on them automatically.